### PR TITLE
v4.0.1 Added the ability to change the API endpoint.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "homepage": "https://www.solutions4mobiles.com"
     }],
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.0.0",
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "support": {
         "issues": "https://github.com/mobiweb/mobiweb-php/issues",

--- a/src/MobiWeb/Http/Client.php
+++ b/src/MobiWeb/Http/Client.php
@@ -8,12 +8,6 @@ class Client {
     const POST = "POST";
     const HTTP_OK = "200";
     const HTTP_CREATED = "201";
-    const HTTP_BAD = "400";
-    const HTTP_UNAUTH = "401";
-    const HTTP_NOTFOUND = "404";
-    const HTTP_UNPROCESS = "422";
-    const HTTP_INTERNALERROR = "500";
-
 
     protected $options = [
         CURLOPT_HEADER => true,
@@ -31,10 +25,10 @@ class Client {
     public function request(string $url = null, string $method = null, array $headers = array(), $data = null): object{
 
         if(!$url){
-            throw new \Exception("Invalid URL: ". $url);
+            throw new \InvalidArgumentException("Invalid URL: ". $url);
         }
         if(!$method){
-            throw new \Exception("Invalid Method: ". $method);
+            throw new \InvalidArgumentException("Invalid Method: ". $method);
         }
 
         switch (strtoupper(trim($method))) {
@@ -47,7 +41,6 @@ class Client {
                 break;
             default:
                 throw new \Exception("Unsupported HTTP Method: ". $method);
-                break;
         }
 
         $options[CURLOPT_URL] = $url;
@@ -95,11 +88,11 @@ class Client {
     protected static function getResponseHeaders(string $response = null, string $headerSize = null): array{
 
         if(!$response){
-            throw new \Exception("Invalid response");
+            throw new \InvalidArgumentException("Invalid response");
         }
 
         if(!$headerSize){
-            throw new \Exception("Invalid response headers");
+            throw new \InvalidArgumentException("Invalid response headers");
         }
 
         $header = substr($response, 0, $headerSize);
@@ -137,5 +130,3 @@ class Client {
     }
 
 }
-
-?>

--- a/src/MobiWeb/Rest/AsynchClient.php
+++ b/src/MobiWeb/Rest/AsynchClient.php
@@ -13,13 +13,13 @@ class AsynchClient {
     const SMS = "sms";
 
 
-    public function __construct(string $username = null, string $password = null){
+    public function __construct(string $username = null, string $password = null, string $apiEndpoint = self::API_ENDPOINT){
 
         if (!$username || !$password) {
             throw new \Exception("Username and Password are required to create a Client");
         }
 
-        $this->auth = new Auth($username,$password,AsynchClient::API_ENDPOINT);
+        $this->auth = new Auth($username,$password,$apiEndpoint);
         if(!$this->auth->authenticate()){
             throw new \Exception("Authentication failed");
         }
@@ -49,5 +49,3 @@ class AsynchClient {
     }
 
 }
-
-?>

--- a/src/MobiWeb/Rest/Client.php
+++ b/src/MobiWeb/Rest/Client.php
@@ -3,27 +3,27 @@
 namespace MobiWeb\Rest;
 
 use MobiWeb\Rest\Authentication as Auth;
-use MobiWeb\Rest\Message;
-use MobiWeb\Rest\HLR;
-use MobiWeb\Rest\OTP;
 use MobiWeb\Rest\Utility as Util;
 
 class Client {
 
     protected $auth;
-    const API_ENDPOINT = "https://sms.solutions4mobiles.com/apis"; 
+    private $apiEndpoint;
+    const API_ENDPOINT_DEFAULT = "https://sms.solutions4mobiles.com/apis";
     const HLR = "hlr"; 
     const SMS = "sms";
     const OTP = "otp";
 
 
-    public function __construct(string $username = null, string $password = null){
+    public function __construct(string $username = null, string $password = null, string $apiEndpoint = self::API_ENDPOINT_DEFAULT){
 
         if (!$username || !$password) {
             throw new \Exception("Username and Password are required to create a Client");
         }
 
-        $this->auth = new Auth($username,$password,Client::API_ENDPOINT);
+        $this->apiEndpoint = $apiEndpoint;
+
+        $this->auth = new Auth($username,$password,$apiEndpoint);
         if(!$this->auth->authenticate()){
             throw new \Exception("Authentication failed");
         }
@@ -46,7 +46,7 @@ class Client {
             throw new \Exception("Mobile number is required to generate an OTP");
         }
 
-        return OTP::generate($this->auth, $mobile, $sender, $message, $validity);
+        return OTP::generate($this->auth, $mobile, $sender, $message, $validity, $this->apiEndpoint);
 
     }
 
@@ -56,7 +56,7 @@ class Client {
             throw new \Exception("Mobile number, OTP pin and OTP ID is required to validate an OTP");
         }
 
-        return OTP::validate($this->auth, $id, $mobile, $pin);
+        return OTP::validate($this->auth, $id, $mobile, $pin, $this->apiEndpoint);
 
     }
 
@@ -66,7 +66,7 @@ class Client {
             throw new \Exception("Mobile number is required to make a HLR Lookup");
         }
 
-        return HLR::lookup($this->auth, $mobile);
+        return HLR::lookup($this->auth, $mobile, $this->apiEndpoint);
 
     }
 
@@ -83,5 +83,3 @@ class Client {
     }
 
 }
-
-?>

--- a/src/MobiWeb/Rest/Error.php
+++ b/src/MobiWeb/Rest/Error.php
@@ -23,10 +23,7 @@ class Error {
 
     public function print(){
 
-        echo "Error - HTTP: " . $this->status_code . " " . $this->status_message . " - API Error: " . print_r($this->errors, 1);
-        return true;
+        return "Error - HTTP: " . $this->status_code . " " . $this->status_message . " - API Error: " . print_r($this->errors, 1);
     }
 
 }
-
-?>

--- a/src/MobiWeb/Rest/HLR.php
+++ b/src/MobiWeb/Rest/HLR.php
@@ -3,7 +3,6 @@
 namespace MobiWeb\Rest;
 
 use MobiWeb\Rest\Authentication as Auth;
-use MobiWeb\Rest\Client as APIClient;
 use MobiWeb\Http\Client as HttpClient;
 use MobiWeb\Rest\Error as APIError;
 
@@ -13,7 +12,7 @@ class HLR {
     const HLR_METHOD = "GET";
 
 
-    public static function lookup(Auth $auth = null, string $mobile): array{
+    public static function lookup(Auth $auth = null, string $mobile, string $apiEndpoint): array{
 
         if (!$auth) {
             throw new \Exception("Cannot query mobile number without authentication");
@@ -22,7 +21,6 @@ class HLR {
         $access_token = $auth->getAccessToken();
         if(!$access_token){
             throw new \Exception("Cannot retrieve Access Token");
-            return false;
         }
 
         $http = new HttpClient();
@@ -30,12 +28,11 @@ class HLR {
         $headers["Authorization"] = "Bearer " . $access_token;
         $body="";
 
-        $executedRequest=$http->request(APIClient::API_ENDPOINT . HLR::HLR_ENDPOINT . $mobile, HLR::HLR_METHOD, $headers, $body);
+        $executedRequest=$http->request($apiEndpoint . HLR::HLR_ENDPOINT . $mobile, HLR::HLR_METHOD, $headers, $body);
 
         if($executedRequest->response->body->status_code != HttpClient::HTTP_OK){
             $apiError = new APIError($executedRequest->response->body->status_code, $executedRequest->response->body->status_message, $executedRequest->response->body->payload->error);
             throw new \Exception($apiError->print());
-            return false;
         }
 
         return array($executedRequest->response->body->payload);

--- a/src/MobiWeb/Rest/Message.php
+++ b/src/MobiWeb/Rest/Message.php
@@ -22,7 +22,6 @@ class Message {
         $access_token = $auth->getAccessToken();
         if(!$access_token){
             throw new \Exception("Cannot retrieve Access Token");
-            return false;
         }
 
         $endpoint = $auth->getEndPoint();
@@ -59,7 +58,7 @@ class Message {
 
         if(count($errors) > 0){
             $apiError = new APIError($executedRequest->response->body->status_code, $executedRequest->response->body->status_message, $errors);
-            $apiError->print();
+            throw new \Exception($apiError->print());
 
         }
 

--- a/src/MobiWeb/Rest/Utility.php
+++ b/src/MobiWeb/Rest/Utility.php
@@ -28,7 +28,6 @@ class Utility {
         $access_token = $auth->getAccessToken();
         if(!$access_token){
             throw new \Exception("Cannot retrieve Access Token");
-            return false;
         }
 
         $endpoint = $auth->getEndPoint();
@@ -41,7 +40,6 @@ class Utility {
         if($executedRequest->response->body->status_code != HttpClient::HTTP_OK){
             $apiError = new APIError($executedRequest->response->body->status_code, $executedRequest->response->body->status_message, $executedRequest->response->body->errors);
             throw new \Exception($apiError->print());
-            return false;
         }
 
         return floatval($executedRequest->response->body->payload->balance);
@@ -57,7 +55,6 @@ class Utility {
         $access_token = $auth->getAccessToken();
         if(!$access_token){
             throw new \Exception("Cannot retrieve Access Token");
-            return false;
         }
 
         $endpoint = $auth->getEndPoint();
@@ -83,7 +80,6 @@ class Utility {
         if($executedRequest->response->body->status_code != HttpClient::HTTP_OK){
             $apiError = new APIError($executedRequest->response->body->status_code, $executedRequest->response->body->status_message, $executedRequest->response->body->errors);
             throw new \Exception($apiError->print());
-            return false;
         }
 
         $currency = $executedRequest->response->body->payload->currency->symbol;
@@ -106,5 +102,3 @@ class Utility {
     }
 
 }
-
-?>


### PR DESCRIPTION
1. Delete redundant "?>"
2. Delete redundant "return false" after throws exceptions
3. Added the ability to change the API endpoint. 

**Example**
_(custom api endpoint)_
```
$username = "";
$password = "";
$apiUrl = "some api url";
$client = new MobiWeb\Rest($username, $password, $apiUrl);
```
_(default api endpoint)_
```
$username = "";
$password = "";
$client = new MobiWeb\Rest($username, $password);
```